### PR TITLE
Match passwords with regexp in list command

### DIFF
--- a/internal/cmd/list/list.go
+++ b/internal/cmd/list/list.go
@@ -33,7 +33,7 @@ func NewCmd(c *cmdutil.Context) *cobra.Command {
 			are provided, all the passwords are listed.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			regex := ""
+			regex := "" // empty string matches all
 			if len(args) > 0 {
 				regex = args[0]
 			}
@@ -57,6 +57,8 @@ func list(passMan pass.Manager, creds *auth.Creds, ident string) error {
 	length := len(passwords) - 1
 	for i, pass := range passwords {
 		fmt.Println(pass.String())
+
+		// print a newline for all but last
 		if i != length {
 			fmt.Println()
 		}

--- a/internal/cmd/list/list.go
+++ b/internal/cmd/list/list.go
@@ -27,13 +27,17 @@ func NewCmd(c *cmdutil.Context) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "list [name]",
 		Short: "un-encrypt and fetch a password from krypt using the filters",
-		Args:  cobra.ExactArgs(1),
+		Args:  cobra.RangeArgs(0, 1),
 		Long: heredoc.Doc(`
 			List all the passwords which match the provided filters. If no filters
 			are provided, all the passwords are listed.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return list(c.PassManager, c.Creds, args[0])
+			regex := ""
+			if len(args) > 0 {
+				regex = args[0]
+			}
+			return list(c.PassManager, c.Creds, regex)
 		},
 	}
 
@@ -50,8 +54,13 @@ func list(passMan pass.Manager, creds *auth.Creds, ident string) error {
 		return err
 	}
 
-	for _, pass := range passwords {
+	length := len(passwords) - 1
+	for i, pass := range passwords {
 		fmt.Println(pass.String())
+		if i != length {
+			fmt.Println()
+		}
 	}
+
 	return nil
 }

--- a/internal/cmd/list/list.go
+++ b/internal/cmd/list/list.go
@@ -45,11 +45,13 @@ func list(passMan pass.Manager, creds *auth.Creds, ident string) error {
 		return cmdutil.ErrNoLogin
 	}
 
-	pass, err := pass.GetS(passMan, ident, creds.Key)
+	passwords, err := pass.Get(passMan, ident, creds.Key)
 	if err != nil {
 		return err
 	}
 
-	fmt.Println(pass.String())
+	for _, pass := range passwords {
+		fmt.Println(pass.String())
+	}
 	return nil
 }

--- a/pkg/pass/pass.go
+++ b/pkg/pass/pass.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/raklaptudirm/krypt/pkg/crypto"
@@ -103,14 +104,36 @@ func GetS(man Manager, ident string, key []byte) (pass *Password, err error) {
 
 		// check if string matches checksum
 		if strings.HasPrefix(hash, ident) {
-			pass, err = decode(pb, key)
-			return
+			return decode(pb, key)
 		}
 
 		pass, err = decode(pb, key)
 		// check if string matches password name
 		if err == nil && strings.Contains(strings.ToLower(pass.Name), ident) {
 			return
+		}
+	}
+
+	err = fmt.Errorf("no password matched %v", ident)
+	return
+}
+
+func Get(man Manager, ident string, key []byte) (pass []Password, err error) {
+	regex, err := regexp.Compile(ident)
+	if err != nil {
+		return
+	}
+
+	pbs, err := man.Passwords()
+	if err != nil {
+		return
+	}
+
+	for _, pb := range pbs {
+		p, err := decode(pb, key)
+		// check if string matches password name
+		if err == nil && regex.Match([]byte(p.Name)) {
+			pass = append(pass, *p)
 		}
 	}
 

--- a/pkg/pass/pass.go
+++ b/pkg/pass/pass.go
@@ -118,6 +118,8 @@ func GetS(man Manager, ident string, key []byte) (pass *Password, err error) {
 	return
 }
 
+// Get fetches a list of password from the provided password manager whose names match
+// the provided regular expression.
 func Get(man Manager, ident string, key []byte) (pass []Password, err error) {
 	regex, err := regexp.Compile(ident)
 	if err != nil {
@@ -131,7 +133,8 @@ func Get(man Manager, ident string, key []byte) (pass []Password, err error) {
 
 	for _, pb := range pbs {
 		p, err := decode(pb, key)
-		// check if string matches password name
+
+		// check if regex matches password name
 		if err == nil && regex.Match([]byte(p.Name)) {
 			pass = append(pass, *p)
 		}

--- a/pkg/pass/pass.go
+++ b/pkg/pass/pass.go
@@ -76,7 +76,7 @@ func decode(b []byte, key []byte) (pass *Password, err error) {
 // String represents Password as a string.
 func (p *Password) String() string {
 	hidden := strings.Repeat("*", len(p.Password))
-	return fmt.Sprintf("Name: %v\nUsername: %v\nPassword: %v\n", p.Name, p.UserID, hidden)
+	return fmt.Sprintf("Name: %v\nUsername: %v\nPassword: %v", p.Name, p.UserID, hidden)
 }
 
 // Write encrypts the password with the provided key and writes it to the provided manager.
@@ -137,6 +137,8 @@ func Get(man Manager, ident string, key []byte) (pass []Password, err error) {
 		}
 	}
 
-	err = fmt.Errorf("no password matched %v", ident)
+	if len(pass) == 0 {
+		err = fmt.Errorf("no password matched %v", ident)
+	}
 	return
 }


### PR DESCRIPTION
Modify the list command to accept a regular expression to match with the password names.
```
$ krypt list [regexp]
```
If no arguments are provided, list all passwords.