### PR TITLE
core: make all commands use regexp

### DIFF
--- a/internal/cmd/edit/edit.go
+++ b/internal/cmd/edit/edit.go
@@ -34,12 +34,12 @@ func NewCmd(c *cmdutil.Context) *cobra.Command {
 			previous one, and store the new one.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			p, err := pass.GetS(c.PassManager, args[0], c.Creds.Key)
+			p, err := pass.Get(c.PassManager, args[0], c.Creds.Key)
 			if err != nil {
 				return err
 			}
 
-			return edit(c.PassManager, c.Creds, p)
+			return edit(c.PassManager, c.Creds, &p[0])
 		},
 	}
 

--- a/internal/cmd/rm/rm.go
+++ b/internal/cmd/rm/rm.go
@@ -34,12 +34,12 @@ func NewCmd(c *cmdutil.Context) *cobra.Command {
 			the master password.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			pass, err := pass.GetS(c.PassManager, args[0], c.Creds.Key)
+			ps, err := pass.Get(c.PassManager, args[0], c.Creds.Key)
 			if err != nil {
 				return err
 			}
 
-			return rm(c.PassManager, c.Creds, pass.Checksum)
+			return rm(c.PassManager, c.Creds, ps[0].Checksum)
 		},
 	}
 

--- a/pkg/pass/pass.go
+++ b/pkg/pass/pass.go
@@ -15,7 +15,6 @@ package pass
 
 import (
 	"bytes"
-	"encoding/hex"
 	"fmt"
 	"regexp"
 	"strings"
@@ -87,35 +86,6 @@ func (p *Password) Write(man Manager, key []byte) error {
 	}
 
 	return man.Write(data)
-}
-
-// GetS fetches a single password from the provided password manager according to
-// the provided identifier.
-func GetS(man Manager, ident string, key []byte) (pass *Password, err error) {
-	ident = strings.ToLower(ident)
-
-	pbs, err := man.Passwords()
-	if err != nil {
-		return
-	}
-
-	for _, pb := range pbs {
-		hash := hex.EncodeToString((crypto.Checksum(pb)))
-
-		// check if string matches checksum
-		if strings.HasPrefix(hash, ident) {
-			return decode(pb, key)
-		}
-
-		pass, err = decode(pb, key)
-		// check if string matches password name
-		if err == nil && strings.Contains(strings.ToLower(pass.Name), ident) {
-			return
-		}
-	}
-
-	err = fmt.Errorf("no password matched %v", ident)
-	return
 }
 
 // Get fetches a list of password from the provided password manager whose names match


### PR DESCRIPTION
`edit` and `rm` command now use regexp to select password.