### PR TITLE
`help`: add help information for all commands

### DIFF
--- a/internal/cmd/add/add.go
+++ b/internal/cmd/add/add.go
@@ -27,7 +27,7 @@ import (
 func NewCmd(c *cmdutil.Context) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "add",
-		Short: "add a new password to krypt, encrypted with your data",
+		Short: "add a new password to krypt, encrypted with your key",
 		Args:  cobra.NoArgs,
 		Long: heredoc.Doc(`
 			Add a new password with a name, username and password to

--- a/internal/cmd/add/add.go
+++ b/internal/cmd/add/add.go
@@ -30,9 +30,12 @@ func NewCmd(c *cmdutil.Context) *cobra.Command {
 		Short: "add a new password to krypt encrypted with your key",
 		Args:  cobra.NoArgs,
 		Long: heredoc.Doc(`
-			Add a new password with a name, username and password to
-			krypt. You will later be able to edit and manipulate this
-			password.
+			Add a new password to krypt, with the provided Name, UserID, and Password.
+			The password will be encrypted and stored, and can only be accessed while
+			logged in.
+
+			This password can be fetched, edited, or removed using the other krypt
+			commands.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return add(c.PassManager, c.Creds)

--- a/internal/cmd/add/add.go
+++ b/internal/cmd/add/add.go
@@ -27,7 +27,7 @@ import (
 func NewCmd(c *cmdutil.Context) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "add",
-		Short: "add a new password to krypt, encrypted with your key",
+		Short: "add a new password to krypt encrypted with your key",
 		Args:  cobra.NoArgs,
 		Long: heredoc.Doc(`
 			Add a new password with a name, username and password to

--- a/internal/cmd/edit/edit.go
+++ b/internal/cmd/edit/edit.go
@@ -27,7 +27,7 @@ import (
 func NewCmd(c *cmdutil.Context) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "edit regexp",
-		Short: "edit a stored password in krypt",
+		Short: "edit the password which matches the provided regexp",
 		Args:  cobra.ExactArgs(1),
 		Long: heredoc.Doc(`
 			Edit is used to edit a password in krypt, delete the

--- a/internal/cmd/edit/edit.go
+++ b/internal/cmd/edit/edit.go
@@ -26,7 +26,7 @@ import (
 
 func NewCmd(c *cmdutil.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "edit [name]",
+		Use:   "edit regexp",
 		Short: "edit a stored password in krypt",
 		Args:  cobra.ExactArgs(1),
 		Long: heredoc.Doc(`

--- a/internal/cmd/edit/edit.go
+++ b/internal/cmd/edit/edit.go
@@ -30,8 +30,11 @@ func NewCmd(c *cmdutil.Context) *cobra.Command {
 		Short: "edit the password which matches the provided regexp",
 		Args:  cobra.ExactArgs(1),
 		Long: heredoc.Doc(`
-			Edit is used to edit a password in krypt, delete the
-			previous one, and store the new one.
+			Edit is used to edit a password stored in krypt. All of the details can
+			be edited, or kept the same by providing an empty input.
+
+			The password to edit is the first password from the list of password
+			names that match the provided regular expression.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			p, err := pass.Get(c.PassManager, args[0], c.Creds.Key)

--- a/internal/cmd/list/list.go
+++ b/internal/cmd/list/list.go
@@ -25,7 +25,7 @@ import (
 
 func NewCmd(c *cmdutil.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "list [name]",
+		Use:   "list [regexp]",
 		Short: "un-encrypt and fetch a password from krypt using the filters",
 		Args:  cobra.RangeArgs(0, 1),
 		Long: heredoc.Doc(`

--- a/internal/cmd/list/list.go
+++ b/internal/cmd/list/list.go
@@ -26,7 +26,7 @@ import (
 func NewCmd(c *cmdutil.Context) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "list [regexp]",
-		Short: "un-encrypt and fetch a password from krypt using the filters",
+		Short: "list the passwords which match the provided regexp",
 		Args:  cobra.RangeArgs(0, 1),
 		Long: heredoc.Doc(`
 			List all the passwords which match the provided filters. If no filters

--- a/internal/cmd/list/list.go
+++ b/internal/cmd/list/list.go
@@ -29,8 +29,10 @@ func NewCmd(c *cmdutil.Context) *cobra.Command {
 		Short: "list the passwords which match the provided regexp",
 		Args:  cobra.RangeArgs(0, 1),
 		Long: heredoc.Doc(`
-			List all the passwords which match the provided filters. If no filters
-			are provided, all the passwords are listed.
+			List all the passwords which match the provided regular expression. If no
+			regular expression is provided, all the passwords are listed.
+
+			The printed passwords are censored by default.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			regex := "" // empty string matches all

--- a/internal/cmd/login/login.go
+++ b/internal/cmd/login/login.go
@@ -31,12 +31,11 @@ func NewCmd(c *cmdutil.Context) *cobra.Command {
 		Short: "login to krypt with your registered master password",
 		Args:  cobra.NoArgs,
 		Long: heredoc.Doc(`
-			Login stores your provided password in a file so that
-			you do not need to enter your	password multiple times.
-	
-			Remember to logout once you are finished,	otherwise the
-			file with your key will	remain and other people may get
-			access to it.
+			Login stores your krypt key so that is does not need to be entered every
+			time a krypt command is used.
+
+			Remember to logout from krypt when you are finished, as your passwords can
+			be accessed as long as you are logged in.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return login(c.AuthManager, c.Creds)

--- a/internal/cmd/logout/logout.go
+++ b/internal/cmd/logout/logout.go
@@ -25,7 +25,7 @@ import (
 func NewCmd(c *cmdutil.Context) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "logout",
-		Short: "logout to block all password access and activity",
+		Short: "logout logs the user out of krypt and blocks access",
 		Args:  cobra.NoArgs,
 		Long: heredoc.Doc(`
 			Logout clears the file which stores your database key,

--- a/internal/cmd/logout/logout.go
+++ b/internal/cmd/logout/logout.go
@@ -25,7 +25,7 @@ import (
 func NewCmd(c *cmdutil.Context) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "logout",
-		Short: "log off krypt by removing the encryption key file",
+		Short: "logout to block all password access and activity",
 		Args:  cobra.NoArgs,
 		Long: heredoc.Doc(`
 			Logout clears the file which stores your database key,

--- a/internal/cmd/logout/logout.go
+++ b/internal/cmd/logout/logout.go
@@ -28,9 +28,10 @@ func NewCmd(c *cmdutil.Context) *cobra.Command {
 		Short: "logout logs the user out of krypt and blocks access",
 		Args:  cobra.NoArgs,
 		Long: heredoc.Doc(`
-			Logout clears the file which stores your database key,
-			so that accessing the passwords requires logging in with
-			the master password.
+			Logout logs you out from krypt, preventing access to the database without
+			the master password. Use this once you are done using krypt.
+
+			After logging out, you need to log back in to access the database.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return logout(c.AuthManager, c.Creds)

--- a/internal/cmd/rm/rm.go
+++ b/internal/cmd/rm/rm.go
@@ -26,7 +26,7 @@ import (
 func NewCmd(c *cmdutil.Context) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "rm regexp",
-		Short: "remove a password from krypt",
+		Short: "remove a password which matches the provided regexp",
 		Args:  cobra.ExactArgs(1),
 		Long: heredoc.Doc(`
 			Logout clears the file which stores your database key,

--- a/internal/cmd/rm/rm.go
+++ b/internal/cmd/rm/rm.go
@@ -25,7 +25,7 @@ import (
 
 func NewCmd(c *cmdutil.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "rm [name]",
+		Use:   "rm regexp",
 		Short: "remove a password from krypt",
 		Args:  cobra.ExactArgs(1),
 		Long: heredoc.Doc(`

--- a/internal/cmd/rm/rm.go
+++ b/internal/cmd/rm/rm.go
@@ -29,9 +29,10 @@ func NewCmd(c *cmdutil.Context) *cobra.Command {
 		Short: "remove a password which matches the provided regexp",
 		Args:  cobra.ExactArgs(1),
 		Long: heredoc.Doc(`
-			Logout clears the file which stores your database key,
-			so that accessing the passwords requires logging in with
-			the master password.
+			Remove deletes the password matching the regular expression from krypt.
+
+			The password to delete is the first password from the list of password
+			names that match the provided regular expression.
 		`),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ps, err := pass.Get(c.PassManager, args[0], c.Creds.Key)

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -27,7 +27,7 @@ import (
 
 func NewCmd(c *cmdutil.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:  "krypt command",
+		Use:  "krypt [command]",
 		Args: cobra.NoArgs,
 
 		SilenceErrors: true,

--- a/internal/cmd/version/version.go
+++ b/internal/cmd/version/version.go
@@ -23,7 +23,7 @@ import (
 func NewCmd(c *cmdutil.Context) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "version",
-		Short: "version prints the current version of print",
+		Short: "version prints the currently used version of krypt",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Print(c.Version.String())

--- a/internal/cmd/version/version.go
+++ b/internal/cmd/version/version.go
@@ -23,7 +23,7 @@ import (
 func NewCmd(c *cmdutil.Context) *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "version",
-		Short: "show the krypt software version",
+		Short: "version prints the current version of print",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			fmt.Print(c.Version.String())


### PR DESCRIPTION
Added comprehensive short and long help information to the krypt commands.