### PR TITLE
`completion`: use custom completion command

### DIFF
--- a/internal/cmd/completion/bash/bash.go
+++ b/internal/cmd/completion/bash/bash.go
@@ -1,0 +1,55 @@
+// Copyright © 2021 Rak Laptudirm <raklaptudirm@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bash
+
+import (
+	"os"
+
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+)
+
+func NewCmd() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "bash",
+		Short: "generate the autocompletion script for bash",
+		Args:  cobra.NoArgs,
+		Long: heredoc.Doc(`
+			Generate the autocompletion script for the bash shell.
+
+			This script depends on the 'bash-completion' package.
+			If it is not installed already, you can install it via your OS's package manager.
+			
+			To load completions in your current shell session:
+			$ source <(krypt completion bash)
+			
+			To load completions for every new session, execute once:
+			Linux:
+				$ krypt completion bash > /etc/bash_completion.d/krypt
+			MacOS:
+				$ krypt completion bash > /usr/local/etc/bash_completion.d/krypt
+			
+			You will need to start a new shell for this setup to take effect.
+		`),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return bash(cmd.Root())
+		},
+	}
+
+	return cmd
+}
+
+func bash(cmd *cobra.Command) error {
+	return cmd.GenBashCompletion(os.Stdout)
+}

--- a/internal/cmd/completion/completion.go
+++ b/internal/cmd/completion/completion.go
@@ -1,0 +1,34 @@
+// Copyright © 2021 Rak Laptudirm <raklaptudirm@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package completion
+
+import (
+	"github.com/MakeNowJust/heredoc"
+	"github.com/spf13/cobra"
+)
+
+func NewCmd() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "completion",
+		Short: "completion generates completion scripts for shells",
+		Args:  cobra.NoArgs,
+		Long: heredoc.Doc(`
+			Generate the autocompletion script for krypt for the specified shell.      
+			See each sub-command's help for details on how to use the generated script.
+		`),
+		Hidden: true,
+	}
+
+	return cmd
+}

--- a/internal/cmd/completion/completion.go
+++ b/internal/cmd/completion/completion.go
@@ -15,6 +15,7 @@ package completion
 
 import (
 	"github.com/MakeNowJust/heredoc"
+	"github.com/raklaptudirm/krypt/internal/cmd/completion/bash"
 	"github.com/spf13/cobra"
 )
 
@@ -29,6 +30,9 @@ func NewCmd() *cobra.Command {
 		`),
 		Hidden: true,
 	}
+
+	// supported shells
+	cmd.AddCommand(bash.NewCmd())
 
 	return cmd
 }

--- a/internal/cmd/completion/fish/fish.go
+++ b/internal/cmd/completion/fish/fish.go
@@ -11,30 +11,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package completion
+package fish
 
 import (
+	"os"
+
 	"github.com/MakeNowJust/heredoc"
-	"github.com/raklaptudirm/krypt/internal/cmd/completion/bash"
-	"github.com/raklaptudirm/krypt/internal/cmd/completion/fish"
 	"github.com/spf13/cobra"
 )
 
 func NewCmd() *cobra.Command {
+	var noDesc *bool
 	var cmd = &cobra.Command{
-		Use:   "completion",
-		Short: "completion generates completion scripts for shells",
+		Use:   "fish",
+		Short: "generate the autocompletion script for fish",
 		Args:  cobra.NoArgs,
 		Long: heredoc.Doc(`
-			Generate the autocompletion script for krypt for the specified shell.      
-			See each sub-command's help for details on how to use the generated script.
+			Generate the autocompletion script for the fish shell.
+
+			To load completions in your current shell session:
+			$ krypt completion fish | source
+			
+			To load completions for every new session, execute once:
+			$ krypt completion fish > ~/.config/fish/completions/krypt.fish  
+			
+			You will need to start a new shell for this setup to take effect.
 		`),
-		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return fish(cmd.Root(), *noDesc)
+		},
 	}
 
-	// supported shells
-	cmd.AddCommand(bash.NewCmd())
-	cmd.AddCommand(fish.NewCmd())
+	noDesc = cmd.Flags().BoolP("no-descriptions", "n", false, "disable completion descriptions")
 
 	return cmd
+}
+
+func fish(cmd *cobra.Command, noDesc bool) error {
+	return cmd.GenFishCompletion(os.Stdout, !noDesc)
 }

--- a/internal/cmd/completion/pwsh/pwsh.go
+++ b/internal/cmd/completion/pwsh/pwsh.go
@@ -11,32 +11,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package completion
+package pwsh
 
 import (
+	"os"
+
 	"github.com/MakeNowJust/heredoc"
-	"github.com/raklaptudirm/krypt/internal/cmd/completion/bash"
-	"github.com/raklaptudirm/krypt/internal/cmd/completion/fish"
-	"github.com/raklaptudirm/krypt/internal/cmd/completion/pwsh"
 	"github.com/spf13/cobra"
 )
 
 func NewCmd() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "completion",
-		Short: "completion generates completion scripts for shells",
+		Use:   "pwsh",
+		Short: "generate the autocompletion script for powershell",
 		Args:  cobra.NoArgs,
 		Long: heredoc.Doc(`
-			Generate the autocompletion script for krypt for the specified shell.      
-			See each sub-command's help for details on how to use the generated script.
+			Generate the autocompletion script for powershell.
+
+			To load completions in your current shell session:
+			PS C:\> krypt completion powershell | Out-String | Invoke-Expression
+			
+			To load completions for every new session, add the output of the above command
+			to your powershell profile.
 		`),
-		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return pwsh(cmd.Root())
+		},
 	}
 
-	// supported shells
-	cmd.AddCommand(bash.NewCmd())
-	cmd.AddCommand(fish.NewCmd())
-	cmd.AddCommand(pwsh.NewCmd())
-
 	return cmd
+}
+
+func pwsh(cmd *cobra.Command) error {
+	return cmd.GenPowerShellCompletion(os.Stdout)
 }

--- a/internal/cmd/completion/zsh/zsh.go
+++ b/internal/cmd/completion/zsh/zsh.go
@@ -11,34 +11,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package completion
+package zsh
 
 import (
+	"os"
+
 	"github.com/MakeNowJust/heredoc"
-	"github.com/raklaptudirm/krypt/internal/cmd/completion/bash"
-	"github.com/raklaptudirm/krypt/internal/cmd/completion/fish"
-	"github.com/raklaptudirm/krypt/internal/cmd/completion/pwsh"
-	"github.com/raklaptudirm/krypt/internal/cmd/completion/zsh"
 	"github.com/spf13/cobra"
 )
 
 func NewCmd() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:   "completion",
-		Short: "completion generates completion scripts for shells",
+		Use:   "zsh",
+		Short: "generate the autocompletion script for zsh",
 		Args:  cobra.NoArgs,
 		Long: heredoc.Doc(`
-			Generate the autocompletion script for krypt for the specified shell.      
-			See each sub-command's help for details on how to use the generated script.
+			Generate the autocompletion script for the zsh shell.
+
+			If shell completion is not already enabled in your environment you will need
+			to enable it.  You can execute the following once:
+			
+			$ echo "autoload -U compinit; compinit" >> ~/.zshrc
+			
+			To load completions for every new session, execute once:
+			# Linux:
+			$ krypt completion zsh > "${fpath[1]}/_krypt"
+			# macOS:
+			$ krypt completion zsh > /usr/local/share/zsh/site-functions/_krypt
+			
+			You will need to start a new shell for this setup to take effect.
 		`),
-		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return zsh(cmd.Root())
+		},
 	}
 
-	// supported shells
-	cmd.AddCommand(zsh.NewCmd())
-	cmd.AddCommand(bash.NewCmd())
-	cmd.AddCommand(fish.NewCmd())
-	cmd.AddCommand(pwsh.NewCmd())
-
 	return cmd
+}
+
+func zsh(cmd *cobra.Command) error {
+	return cmd.GenZshCompletion(os.Stdout)
 }

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -15,6 +15,7 @@ package root
 
 import (
 	"github.com/raklaptudirm/krypt/internal/cmd/add"
+	"github.com/raklaptudirm/krypt/internal/cmd/completion"
 	"github.com/raklaptudirm/krypt/internal/cmd/edit"
 	"github.com/raklaptudirm/krypt/internal/cmd/help"
 	"github.com/raklaptudirm/krypt/internal/cmd/list"
@@ -28,7 +29,7 @@ import (
 
 func NewCmd(c *cmdutil.Context) *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:  "krypt [command]",
+		Use:  "krypt",
 		Args: cobra.NoArgs,
 
 		SilenceErrors: true,
@@ -56,6 +57,7 @@ func NewCmd(c *cmdutil.Context) *cobra.Command {
 	cmd.AddCommand(login.NewCmd(c))
 	cmd.AddCommand(logout.NewCmd(c))
 	cmd.AddCommand(version.NewCmd(c))
+	cmd.AddCommand(completion.NewCmd())
 
 	return cmd
 }


### PR DESCRIPTION
Use a custom hidden completion command instead of the inbuilt one.
```
ψ bin/krypt help completion
Generate the autocompletion script for krypt for the specified shell.      
See each sub-command's help for details on how to use the generated script.

Usage:
  krypt completion [command]

Available Commands:
  bash        generate the autocompletion script for bash
  fish        generate the autocompletion script for fish
  pwsh        generate the autocompletion script for powershell
  zsh         generate the autocompletion script for zsh

Global Flags:
  -h, --help      show help for command
  -v, --version   show software version

Use "krypt completion [command] --help" for more information about a command.
```